### PR TITLE
Add environment variables config

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+config.json

--- a/api/config_example.json
+++ b/api/config_example.json
@@ -1,0 +1,18 @@
+{
+  "development": {
+    "CONFIG_ID": "DEVELOPMENT",
+    "MONGO_HOSTNAME": "localhost",
+    "MONGO_PORT": "27017",
+    "MONGO_DB": "devbev",
+    "NODE_PORT": 8000
+  },
+  "production": {
+    "CONFIG_ID": "PRODUCTION",
+    "MONGO_USERNAME": "USERNAME",
+    "MONGO_PASSWORD": "PASSWORD",
+    "MONGO_HOSTNAME": "HOST",
+    "MONGO_PORT": "27017",
+    "MONGO_DB": "devbev",
+    "NODE_PORT": 8000
+  }
+}

--- a/api/index.js
+++ b/api/index.js
@@ -4,24 +4,41 @@ const logger = require("morgan");
 const bodyParser = require("body-parser");
 const cors = require("cors");
 const mongoose = require("mongoose");
-const {
-  ObjectID
-} = require('mongodb');
+const { ObjectID } = require("mongodb");
 
 // Initialize the Express App
 const app = express();
 
 // Local files required
-const Beer = require('./models/beer');
-const Coffee = require('./models/coffee');
-const Liquor = require('./models/liquor');
-const Tea = require('./models/tea');
-const Drink = require('./models/drink');
-const routeDrinks = require('./routes/drinks');
+const Beer = require("./models/beer");
+const Coffee = require("./models/coffee");
+const Liquor = require("./models/liquor");
+const Tea = require("./models/tea");
+const Drink = require("./models/drink");
+const routeDrinks = require("./routes/drinks");
+
+// Set environment variables
+const config = require("./utilities/config");
+
+let dbUrl;
+
+if (process.env.NODE_ENV === "production") {
+  dbUrl = `mongodb://${global.gConfig.MONGO_USERNAME}:${
+    global.gConfig.MONGO_PASSWORD
+  }@${global.gConfig.MONGO_HOSTNAME}:${global.gConfig.MONGO_PORT}/${
+    global.gConfig.MONGO_DB
+  }?authSource=admin`;
+} else {
+  dbUrl = `mongodb://${global.gConfig.MONGO_HOSTNAME}:${
+    global.gConfig.MONGO_PORT
+  }/${global.gConfig.MONGO_DB}`;
+}
+
+console.log(`${global.gConfig.CONFIG_ID} variables loaded`);
 
 // Mongoose Connect
 mongoose
-  .connect("mongodb://localhost:27017/devbev", {
+  .connect(dbUrl, {
     useNewUrlParser: true
   })
   .then(() => {
@@ -34,21 +51,23 @@ mongoose
 // Apply body Parser and server public assets and routes
 app.use(logger("dev"));
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({
-  extended: false
-}));
+app.use(
+  bodyParser.urlencoded({
+    extended: false
+  })
+);
 app.use(cors());
 
 // GET by type and display name, image, rating
 app.get("/drinks", routeDrinks.getByTypeOrAll);
 
 // GET by ID and display all info
-app.get('/drinks/:id', routeDrinks.getIndividualDrink);
+app.get("/drinks/:id", routeDrinks.getIndividualDrink);
 
 // POST /drink
-app.post('/drinks', routeDrinks.postDrinks);
+app.post("/drinks", routeDrinks.postDrinks);
 
 // Start app
-app.listen(8000, "localhost", () => {
-  console.log("listening on port 8000");
+app.listen(global.gConfig.NODE_PORT, () => {
+  console.log(`listening on port ${global.gConfig.NODE_PORT}`);
 });

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prod": "NODE_ENV=production node index.js"
   },
   "keywords": [],
   "author": "",

--- a/api/utilities/config.js
+++ b/api/utilities/config.js
@@ -1,0 +1,7 @@
+const config = require("../config.json");
+const defaultConfig = config.development;
+const environment = process.env.NODE_ENV || "development";
+const environmentConfig = config[environment];
+const finalConfig = Object.assign(defaultConfig, environmentConfig);
+
+global.gConfig = finalConfig;


### PR DESCRIPTION
Allows custom environment variables depending on the environment (development or production)

You will need to create ```config.json``` in ```/api```. The config_example.json file in this PR can be copied and renamed to config.json.

Development is always the default, we can start our development environment the same way we have been (npm start).

When we deploy on the server, ```npm run prod``` will use the production variables and connect to the production database.

If anyone is curious, I used this post for reference:
https://codeburst.io/node-js-best-practices-smarter-ways-to-manage-config-files-and-variables-893eef56cbef
