### PR TITLE
Correct api url for production

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_DEV_API_URL="http://devbev.io/drinks/"
+REACT_APP_DEV_API_URL="https://devbev.io/drinks/"


### PR DESCRIPTION
Changing the API url from ```http``` to ```https``` in the production variable file. Had to manually change this on the server because requests to ```http``` would fail