### PR TITLE
Drinks GET route refactor and added name query

### DIFF
--- a/api/models/beer.js
+++ b/api/models/beer.js
@@ -16,4 +16,4 @@ const beerSchema = new Schema(
   options
 );
 
-module.exports = Beer = Drink.discriminator("Beer", beerSchema);
+module.exports = Beer = Drink.discriminator("beer", beerSchema);

--- a/api/models/coffee.js
+++ b/api/models/coffee.js
@@ -19,4 +19,4 @@ const coffeeSchema = new Schema(
   options
 );
 
-module.exports = Coffee = Drink.discriminator("Coffee", coffeeSchema);
+module.exports = Coffee = Drink.discriminator("coffee", coffeeSchema);

--- a/api/models/liquor.js
+++ b/api/models/liquor.js
@@ -13,4 +13,4 @@ const liquorSchema = new Schema(
   options
 );
 
-module.exports = Liquor = Drink.discriminator("Liquor", liquorSchema);
+module.exports = Liquor = Drink.discriminator("liquor", liquorSchema);

--- a/api/models/tea.js
+++ b/api/models/tea.js
@@ -16,4 +16,4 @@ const teaSchema = new Schema(
   options
 );
 
-module.exports = Tea = Drink.discriminator("Tea", teaSchema);
+module.exports = Tea = Drink.discriminator("tea", teaSchema);

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -16,4 +16,4 @@ const userSchema = new Schema({
   }
 });
 
-module.exports = User = mongoose.model("User", userSchema);
+module.exports = User = mongoose.model("user", userSchema);

--- a/api/routes/drinks.js
+++ b/api/routes/drinks.js
@@ -7,66 +7,21 @@ const _ = require("lodash");
 // Default is return all drinks
 exports.getByTypeOrAll = (req, res) => {
   let type = req.query.type;
+  const query = {};
 
-  // Checks if /drinks?type=<case> then displays
-  switch (type) {
-    case "beer":
-      Promise.all([
-        Beer.find()
-          .select("name image rating _id")
-          .exec()
-      ]).then(([drinks]) =>
-        res.json({
-          drinks
-        })
-      );
-      break;
-    case "tea":
-      Promise.all([
-        Tea.find()
-          .select("name image rating _id")
-          .exec()
-      ]).then(([drinks]) =>
-        res.json({
-          drinks
-        })
-      );
-      break;
-    case "coffee":
-      Promise.all([
-        Coffee.find()
-          .select("name image rating _id")
-          .exec()
-      ]).then(([drinks]) =>
-        res.json({
-          drinks
-        })
-      );
-      break;
-    case "liquor":
-      Promise.all([
-        Liquor.find()
-          .select("name image rating _id")
-          .exec()
-      ]).then(([drinks]) =>
-        res.json({
-          drinks
-        })
-      );
-      break;
-    // Displays everything as default
-    default:
-      Promise.all([
-        Drink.find()
-          .select("name image rating type _id")
-          .exec()
-      ]).then(([drinks]) =>
-        res.json({
-          drinks
-        })
-      );
-      break;
+  if (type) {
+    query["drinkType"] = type;
   }
+
+  Promise.all([
+    Drink.find(query)
+      .select("name image rating _id")
+      .exec()
+  ]).then(([drinks]) =>
+    res.json({
+      drinks
+    })
+  );
 };
 
 // GET by ID
@@ -169,14 +124,15 @@ exports.deleteDrink = (req, res) => {
   // Validate ID
   if (!ObjectID.isValid(id)) return res.status(404).send();
 
-  Drink.findByIdAndRemove(id).then((drink) => {
-    if (!drink) return res.status(404).send();
-  
-    res.send({drink});
-  }).catch(e => {
-    res.status(400).send();
-  });
+  Drink.findByIdAndRemove(id)
+    .then(drink => {
+      if (!drink) return res.status(404).send();
 
+      res.send({ drink });
+    })
+    .catch(e => {
+      res.status(400).send();
+    });
 };
 
 // Update a Drink
@@ -184,20 +140,33 @@ exports.updateDrink = (req, res) => {
   let id = req.params.id;
 
   // All fields except Image
-  const updatableFields = ["name", "tastingNotes", "comments", "rating", 
-  "style", "source", "beanType", "brewTime", 
-  "strength", "typeOfLiquor", "leafType", "steepTime" ];
+  const updatableFields = [
+    "name",
+    "tastingNotes",
+    "comments",
+    "rating",
+    "style",
+    "source",
+    "beanType",
+    "brewTime",
+    "strength",
+    "typeOfLiquor",
+    "leafType",
+    "steepTime"
+  ];
 
   let body = _.pick(req.body, ...updatableFields);
 
   // Validate ID
   if (!ObjectID.isValid(id)) return res.status(404).send();
 
-  Drink.findByIdAndUpdate(id, {$set: body}, {new: true}).then(drink => {
-    if (!drink) return res.status(400).send();
+  Drink.findByIdAndUpdate(id, { $set: body }, { new: true })
+    .then(drink => {
+      if (!drink) return res.status(400).send();
 
-    res.send({drink});
-  }).catch(e => {
-    res.status(400).send();
-  });
+      res.send({ drink });
+    })
+    .catch(e => {
+      res.status(400).send();
+    });
 };

--- a/api/routes/drinks.js
+++ b/api/routes/drinks.js
@@ -6,11 +6,15 @@ const _ = require("lodash");
 // GET by type
 // Default is return all drinks
 exports.getByTypeOrAll = (req, res) => {
-  let type = req.query.type;
+  const type = req.query.type;
+  const name = req.query.name;
   const query = {};
 
   if (type) {
     query["drinkType"] = type;
+  }
+  if (name) {
+    query["name"] = { $regex: name, $options: "i" };
   }
 
   Promise.all([

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -9,16 +9,16 @@ function NavBar(props) {
           <li id="all" onClick={() => props.addFilter("none")}>
             all
           </li>
-          <li id="beer" onClick={() => props.addFilter("Beer")}>
+          <li id="beer" onClick={() => props.addFilter("beer")}>
             beer
           </li>
-          <li id="tea" onClick={() => props.addFilter("Tea")}>
+          <li id="tea" onClick={() => props.addFilter("tea")}>
             tea
           </li>
-          <li id="coffee" onClick={() => props.addFilter("Coffee")}>
+          <li id="coffee" onClick={() => props.addFilter("coffee")}>
             coffee
           </li>
-          <li id="liquor" onClick={() => props.addFilter("Liquor")}>
+          <li id="liquor" onClick={() => props.addFilter("liquor")}>
             liquor
           </li>
           <li id="add" onClick={() => props.addDrinkForm()}>


### PR DESCRIPTION
Added an additional query option on the drinks GET route. Passing a name attribute will return any drink names that contain that query. We can use this for the drink search on the front-end.

Also found a cleaner way to use mongoose to query by drinkType. @Jc7j Check it out!


With name query:
![Screenshot from 2019-05-01 16-24-07](https://user-images.githubusercontent.com/22715037/57046531-18b01880-6c2e-11e9-97ce-12aeab1eceb2.png)

Name and type query:
![Screenshot from 2019-05-01 16-24-36](https://user-images.githubusercontent.com/22715037/57046537-1c439f80-6c2e-11e9-80ce-9e0c074b8680.png)
